### PR TITLE
Bug fix: Preserve code blocks in a list

### DIFF
--- a/src/Modules/MarkdownExtraParser.php
+++ b/src/Modules/MarkdownExtraParser.php
@@ -225,7 +225,7 @@ class MarkdownExtraParser extends ParsedownExtra {
 	 * @return string       Markdown/HTML content with escaped code blocks
 	 */
 	public function codeblock_preserve( $text ) {
-		return preg_replace_callback( "/^([`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_preserve' ), $text );
+		return preg_replace_callback( "/^(\s*[`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_preserve' ), $text );
 	}
 
 	/**
@@ -250,7 +250,7 @@ class MarkdownExtraParser extends ParsedownExtra {
 	 * @return string Markdown/HTML content
 	 */
 	public function codeblock_restore( $text ) {
-		return preg_replace_callback( "/^([`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_restore' ), $text );
+		return preg_replace_callback( "/^(\s*[`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_restore' ), $text );
 	}
 
 	/**

--- a/src/Modules/MarkdownParser.php
+++ b/src/Modules/MarkdownParser.php
@@ -220,7 +220,7 @@ class MarkdownParser extends Parsedown {
 	 * @return string       Markdown/HTML content with escaped code blocks
 	 */
 	public function codeblock_preserve( $text ) {
-		return preg_replace_callback( "/^([`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_preserve' ), $text );
+		return preg_replace_callback( "/^(\s*[`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_preserve' ), $text );
 	}
 
 	/**
@@ -245,7 +245,7 @@ class MarkdownParser extends Parsedown {
 	 * @return string Markdown/HTML content
 	 */
 	public function codeblock_restore( $text ) {
-		return preg_replace_callback( "/^([`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_restore' ), $text );
+		return preg_replace_callback( "/^(\s*[`~]{3})([^`\n]+)?\n([^`~]+)(\\1)/m", array( $this, 'do_codeblock_restore' ), $text );
 	}
 
 	/**


### PR DESCRIPTION
Code blocks aren't preserved when they are in a list:

![2019-05-03-044347_1920x1080_scrot](https://user-images.githubusercontent.com/1093382/57117980-557c2c80-6d60-11e9-82cf-d5cd79e690d2.png)

![2019-05-03-044701_1920x1080_scrot](https://user-images.githubusercontent.com/1093382/57117981-57de8680-6d60-11e9-98e4-b3ad912f9700.png)
