### PR TITLE
Toc excludes comment

### DIFF
--- a/src/Modules/Toc.php
+++ b/src/Modules/Toc.php
@@ -97,7 +97,7 @@ class Toc extends ModuleAbstract {
 			$script .= '
 				$("#md-post-toc").initTOC({
 					selector: "h2, h3, h4, h5, h6",
-					scope: ".post",
+					scope: ".post-content",
 				});
 
 				$("#md-post-toc a").click(function(e) {


### PR DESCRIPTION
In some themes the comment div could be taken as a title. Modify the scope will work.