### PR TITLE
Compatible with PHP 7.4

### DIFF
--- a/src/Modules/TaskList.php
+++ b/src/Modules/TaskList.php
@@ -19,7 +19,6 @@ class TaskList {
 	 * Constructer.
 	 */
 	public function __construct() {
-		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
In PHP 7.4, the following warning was shown:

```text
PHP Deprecated:  Cannot use "parent" when current class scope has no parent in /home/razonyang/Projects/razonyang/githuber-md/src/Modules/TaskList.php on line 22
```