### PR TITLE
fix KaTeX display mode

### DIFF
--- a/src/Controllers/Markdown.php
+++ b/src/Controllers/Markdown.php
@@ -916,6 +916,16 @@ class Markdown extends ControllerAbstract {
 	 */
 	public function transform( $text, $args = array() ) {
 
+		// Render KaTeX display markup beofre processing code blocks to ensure code block tag <pre><code> is respected
+		if ( $this->is_support_katex ) {
+			$text = Module\KaTeX::katex_display_markup( $text );
+		}
+				
+		// Render KaTeX inline markup beofre processing code blocks to ensure code block tag <code> is respected
+		if ( $this->is_support_katex ) {
+			$text = Module\KaTeX::katex_inline_markup( $text );
+		}
+
 		$is_decode_code_blocks = ( 'yes' === githuber_get_option( 'decode_code_blocks', 'githuber_preferences' ) ) ? true : false;
 
 		$args = wp_parse_args( $args, array(
@@ -955,11 +965,6 @@ class Markdown extends ControllerAbstract {
 		// Render Github Flavored Markdown task lists if this module is enabled.
 		if ( $this->is_support_task_list ) {
 			$text = Module\TaskList::parse_gfm_task_list( $text );
-		}
-
-		// Render KaTeX inline markup.
-		if ( $this->is_support_katex ) {
-			$text = Module\KaTeX::katex_inline_markup( $text );
 		}
 
 		// Render MathJax inline markup.

--- a/src/Controllers/Setting.php
+++ b/src/Controllers/Setting.php
@@ -881,7 +881,50 @@ class Setting extends ControllerAbstract {
 						'default'    => __( 'default', 'wp-githuber-md' ),
 						'cloudflare' => 'cdnjs.cloudflare.com',
 						'jsdelivr'   => 'cdn.jsdelivr.net',
+						'custom'     => __( 'custom', 'wp-githuber-md' )
 					)
+				),
+
+				array(
+                    'name'              => 'katex_src_custom_css_url',
+					'label'             => __( 'KaTeX Custom CSS URL', 'wp-githuber-md' ),
+                    'placeholder'       => '',
+                    'type'              => 'text',
+					'default'           => '',
+					'parent'            => 'support_katex',
+					'sanitize_callback' => '',
+				),
+
+				array(
+                    'name'              => 'katex_src_custom_js_url',
+					'label'             => __( 'KaTeX CustomJS URL', 'wp-githuber-md' ),
+                    'placeholder'       => '',
+                    'type'              => 'text',
+					'default'           => '',
+					'parent'            => 'support_katex',
+					'sanitize_callback' => '',
+				),
+
+				array(
+                    'name'              => 'katex_custom_regex_inline',
+					'label'             => __( 'KaTeX Custom Inline Regex', 'wp-githuber-md' ),
+					'desc'    			=> __( 'default to \'' . htmlspecialchars('%<code>\$\$((?:[^$]+ |(?<=(?<!\\\\)\\\\)\$ )+)(?<!\\\\)\$\$<\/code>%ix') . '\'', 'wp-githuber-md' ),
+                    'placeholder'       => '',
+                    'type'              => 'text',
+					'default'           => '%<code>\$\$((?:[^$]+ |(?<=(?<!\\\\)\\\\)\$ )+)(?<!\\\\)\$\$<\/code>%ix',
+					'parent'            => 'support_katex',
+					'sanitize_callback' => '',
+				),
+
+				array(
+                    'name'              => 'katex_custom_regex_display',
+					'label'             => __( 'KaTeX Custom Display Regex', 'wp-githuber-md' ),
+					'desc'    			=> __( 'default to code block style' ),
+                    'placeholder'       => '',
+                    'type'              => 'text',
+					'default'           => '',
+					'parent'            => 'support_katex',
+					'sanitize_callback' => '',
 				),
 
 				array(

--- a/src/Modules/KaTeX.php
+++ b/src/Modules/KaTeX.php
@@ -72,6 +72,10 @@ class KaTeX extends ModuleAbstract {
 					$style_url = 'https://cdn.jsdelivr.net/npm/katex@' . $this->katex_version . '/dist/katex.min.css';
 					break;
 
+				case 'custom':
+					$style_url = githuber_get_option( 'katex_src_custom_css_url', 'githuber_modules' );
+					break;	
+
 				default:
 					$style_url = $this->githuber_plugin_url . 'assets/vendor/katex/katex.min.css';
 					break;
@@ -97,6 +101,10 @@ class KaTeX extends ModuleAbstract {
 
 				case 'jsdelivr':
 					$script_url = 'https://cdn.jsdelivr.net/npm/katex@' . $this->katex_version . '/dist/katex.min.js';
+					break;
+
+				case 'custom':
+					$script_url = githuber_get_option( 'katex_src_custom_js_url', 'githuber_modules' );
 					break;
 
 				default:
@@ -163,7 +171,7 @@ class KaTeX extends ModuleAbstract {
 	 */
 	public static function katex_inline_markup( $content ) {
 
-		$regex = '%<code>\$\$((?:[^$]+ |(?<=(?<!\\\\)\\\\)\$ )+)(?<!\\\\)\$\$<\/code>%ix';
+		$regex = githuber_get_option( 'katex_custom_regex_inline', 'githuber_modules' );
 		$content = preg_replace_callback( $regex, function() {
 			$matches = func_get_arg(0);
 
@@ -171,6 +179,28 @@ class KaTeX extends ModuleAbstract {
 				$katex = $matches[1];
 				$katex = str_replace( array( '&lt;', '&gt;', '&quot;', '&#039;', '&#038;', '&amp;', "\n", "\r" ), array( '<', '>', '"', "'", '&', '&', ' ', ' ' ), $katex );
 				return '<code class="katex-inline">' . trim( $katex ) . '</code>';
+			}
+		}, $content );
+
+		return $content;
+	}
+
+	public static function katex_display_markup( $content ) {
+
+		$regex = githuber_get_option( 'katex_custom_regex_display', 'githuber_modules' );
+
+		// abort if native
+		if ( $regex == '' ) {
+			return $content;
+		}
+
+		$content = preg_replace_callback( $regex, function() {
+			$matches = func_get_arg(0);
+
+			if ( ! empty( $matches[1] ) ) {
+				$katex = $matches[1];
+				$katex = str_replace( array( '&lt;', '&gt;', '&quot;', '&#039;', '&#038;', '&amp;', "\n", "\r" ), array( '<', '>', '"', "'", '&', '&', ' ', ' ' ), $katex );
+				return '<pre><code class="language-katex">' . trim( $katex ) . '</code></pre>';
 			}
 		}, $content );
 

--- a/src/Modules/KaTeX.php
+++ b/src/Modules/KaTeX.php
@@ -116,15 +116,15 @@ class KaTeX extends ModuleAbstract {
 				(function($) {
 					$(function() {
 						if (typeof katex !== "undefined") {
-                            if ($(".language-katex").length > 0) {
-								$(".language-katex").parent("pre").attr("style", "text-align: center; background: none;");
-								$(".language-katex").addClass("katex-container").removeClass("language-katex");
+							if ($(".language-katex").length > 0) {
+								$(".language-katex").parent("pre").wrapInner("<div/>").children(0).unwrap();
+								$(".language-katex").wrapInner("<div/>").children(0).unwrap().addClass("katex-container");
 								$(".katex-container").each(function() {
 									var katexText = $(this).text();
 									var el = $(this).get(0);
 									if ($(this).parent("code").length == 0) {
 										try {
-											katex.render(katexText, el)
+											katex.render(katexText, el, {displayMode:true})
 										} catch (err) {
 											$(this).html("<span class=\'err\'>" + err)
 										}
@@ -146,7 +146,7 @@ class KaTeX extends ModuleAbstract {
 							}
 						}
 					});
-                })(jQuery);
+				})(jQuery);
 			</script>
 		';
 		echo preg_replace( '/\s+/', ' ', $script );


### PR DESCRIPTION
Use native KaTeX display mode to avoid rendering issue on `\tag{}`.

Use `<div><div>` instead of `<pre><code>` to avoid css issue as math equation is not programming code.