### PR TITLE
Allow custom post types to use Gutenberg editor if it is enabled

### DIFF
--- a/src/Controllers/Markdown.php
+++ b/src/Controllers/Markdown.php
@@ -184,6 +184,13 @@ class Markdown extends ControllerAbstract {
 		// Get post type from curren screen.
 		$current_post_type = githuber_get_current_post_type();
 
+        $args = array(
+            'public'   => true,
+            '_builtin' => false, // for custom post types
+            'show_in_rest' => true, // for custom post types with Gutenberg editor enabled
+        );
+        $custom_post_types = get_post_types( $args );
+
 		// Feature request #98
 		if ( 'yes' === githuber_get_option( 'richeditor_by_default', 'githuber_preferences' ) ) {
 
@@ -191,7 +198,7 @@ class Markdown extends ControllerAbstract {
 				$rich_editing = new RichEditing();
 				$rich_editing->enable();
 
-				if ( empty( $current_post_type ) || 'post' === $current_post_type || 'page' === $current_post_type ) {
+				if ( empty( $current_post_type ) || 'post' === $current_post_type || 'page' === $current_post_type || in_array($current_post_type, $custom_post_types) ) {
 					$rich_editing->enable_gutenberg();
 				}
 
@@ -206,8 +213,8 @@ class Markdown extends ControllerAbstract {
 			$rich_editing->enable();
 
 			// Custom post types are not supporting Gutenberg by default for now, so
-			// We only enable Gutenberg for `post` and `page`...
-			if ( 'post' === $current_post_type || 'page' === $current_post_type ) {
+            // We only enable Gutenberg for `post`, `page` and custom post types with Gutenberg enabled
+			if ( 'post' === $current_post_type || 'page' === $current_post_type || in_array($current_post_type, $custom_post_types) ) {
 				$rich_editing->enable_gutenberg();
 			}
 		} else {
@@ -217,7 +224,7 @@ class Markdown extends ControllerAbstract {
 				$rich_editing = new RichEditing();
 				$rich_editing->enable();
 
-				if ( 'post' === $current_post_type || 'page' === $current_post_type ) {
+				if ( 'post' === $current_post_type || 'page' === $current_post_type || in_array($current_post_type, $custom_post_types) ) {
 					$rich_editing->enable_gutenberg();
 				}
 


### PR DESCRIPTION
Hi, we run into a problem, that after activating your plugin we were not able to use block editor for our custom post types. This issue was also raised here: https://github.com/terrylinooo/githuber-md/issues/76. What I'm introducing with this PR is adding a condition, to allow Gutenberg for Custom Post Types that have it enabled (`show_in_rest` option is set to true)