### PR TITLE
fixed jsdeliver url for line-numbers修复jsdeliver  url地址

### DIFF
--- a/src/Modules/Prism.php
+++ b/src/Modules/Prism.php
@@ -296,7 +296,7 @@ class Prism extends ModuleAbstract {
 				case 'jsdelivr':
 					$style_url[] = 'https://cdn.jsdelivr.net/npm/prismjs@' . $this->prism_version . '/themes/' . $theme . '.css';
 					if ( 'yes' === $prism_line_number ) {
-						$style_url[] = 'https://cdnjs.cloudflare.com/ajax/libs/prism/' . $this->prism_version . '/plugins/line-numbers/prism-line-numbers.css';
+						$style_url[] ='https://cdn.jsdelivr.net/npm/prismjs@' . $this->prism_version . '/plugins/line-numbers/prism-line-numbers.css';
 					}
 					break;
 


### PR DESCRIPTION
case的是jsdeliver但是返回的是cloudflare的cdn。