### PR TITLE
feat: use plain old js for link target

### DIFF
--- a/src/Views/assets/js.php
+++ b/src/Views/assets/js.php
@@ -1,5 +1,5 @@
-<?php 
-if ( ! defined('GITHUBER_PLUGIN_NAME') ) die; 
+<?php
+if (!defined('GITHUBER_PLUGIN_NAME')) die;
 /**
  * View for CSS
  *
@@ -12,17 +12,16 @@ if ( ! defined('GITHUBER_PLUGIN_NAME') ) die;
  */
 ?>
 
-<?php if ( '_blank' === githuber_get_option( 'post_link_target_attribute', 'githuber_preferences' ) ) : ?>
+<?php if ('_blank' === githuber_get_option('post_link_target_attribute', 'githuber_preferences')) : ?>
     <script id="preference-link-target">
-        (function($) {
-            $(function() {
-                $(".post").find("a").each(function() {
-                    var link_href = $(this).attr("href");
-                    if (link_href.indexOf("#") == -1) {
-                        $(this).attr("target", "_blank");
-                    }
-                });
+        document.addEventListener('DOMContentLoaded', function() {
+            let links = document.querySelectorAll('.post a');
+            links.forEach(function(link) {
+                let linkHref = link.getAttribute('href');
+                if (linkHref && linkHref.indexOf('#') === -1) {
+                    link.setAttribute('target', '_blank');
+                }
             });
-        })(jQuery);
+        });
     </script>
 <?php endif; ?>


### PR DESCRIPTION
jquery isn't included by default in wp anymore