### PR TITLE
Fix inline backtick rendering in safe mode

### DIFF
--- a/src/Controllers/Markdown.php
+++ b/src/Controllers/Markdown.php
@@ -952,8 +952,9 @@ class Markdown extends ControllerAbstract {
 		// sometimes we get an encoded > at start of line, breaking blockquotes
 		$text = preg_replace( '/^&gt;/m', '>', $text );
 
-		// If we're not using the code shortcode, prevent over-encoding.
-		if ( $args['decode_code_blocks'] ) {
+		// Decode pre-escaped fenced blocks to prevent double-encoding on save.
+		// This can happen when save-time filters run before Markdown transform.
+		if ( $args['decode_code_blocks'] || $this->has_encoded_fenced_code_blocks( $text ) ) {
 			$text = $this->restore_code_blocks( $text );
 		}
 
@@ -989,6 +990,19 @@ class Markdown extends ControllerAbstract {
 		}
 
 		return $text;
+	}
+
+	/**
+	 * Detect whether fenced code blocks appear to be HTML-encoded already.
+	 *
+	 * @param string $text Content to inspect.
+	 * @return bool
+	 */
+	protected function has_encoded_fenced_code_blocks( $text ) {
+		return (bool) preg_match(
+			"/^(\t*[`~]{3})([^`\n]+)?\n[\s\S]*?(?:&amp;quot;|&quot;|&#0?39;|&lt;|&gt;|&amp;#)[\s\S]*?\n(\\1)/m",
+			$text
+		);
 	}
 
 	/**

--- a/src/Modules/MarkdownExtraParser.php
+++ b/src/Modules/MarkdownExtraParser.php
@@ -232,7 +232,9 @@ class MarkdownExtraParser extends ParsedownExtra {
 				return '<code class="kb-btn">' . $this->hash_block( esc_html( substr( $matches[1], 1, -1 ) ) ) . '</code>';
 			}
 		}
-		return '<code>' . $this->hash_block( esc_html( $matches[1] ) ) . '</code>';
+		// Keep standard inline code as markdown so Parsedown safe mode can render
+		// valid <code> elements instead of escaping injected raw HTML tags.
+		return '`' . $this->hash_block( esc_html( $matches[1] ) ) . '`';
 	}
 
 	/**

--- a/src/Modules/MarkdownParser.php
+++ b/src/Modules/MarkdownParser.php
@@ -222,7 +222,9 @@ class MarkdownParser extends Parsedown {
 				return '<code class="kb-btn">' . $this->hash_block( esc_html( $matches[1] ) ) . '</code>';
 			}
 		}
-		return '<code>' . $this->hash_block( esc_html( $matches[1] ) ) . '</code>';
+		// Keep standard inline code as markdown so Parsedown safe mode can render
+		// valid <code> elements instead of escaping injected raw HTML tags.
+		return '`' . $this->hash_block( esc_html( $matches[1] ) ) . '`';
 	}
 
 	/**


### PR DESCRIPTION
Preserve standard inline code as markdown tokens so Parsedown safe mode emits proper code elements instead of escaped literal tags. This fixes issue #393 where inline code appeared as literal HTML text.

Cursor generated the code, fixes the issue in my environment.   Previously backticks where just giving me

`something`
became
<code>something</code>